### PR TITLE
add description into gemspec to prevent build error.

### DIFF
--- a/erlang_template_helper.gemspec
+++ b/erlang_template_helper.gemspec
@@ -4,9 +4,9 @@ require File.expand_path('../lib/erlang_template_helper/version', __FILE__)
 Gem::Specification.new do |gem|
   gem.authors       = ["Daniel Reverri"]
   gem.email         = ["reverri@gmail.com"]
-  gem.description   = %q{TODO: Write a gem description}
-  gem.summary       = %q{TODO: Write a gem summary}
-  gem.homepage      = ""
+  gem.description   = %q{Erlang Template Helper}
+  gem.summary       = %q{This library allows one to specify Erlang config and args files in JSON.}
+  gem.homepage      = "https://github.com/basho/erlang_template_helper"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
`rake build` requires a specified description.

```
% rake build
rake aborted!
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    "FIXME" or "TODO" is not a description
Tasks: TOP => build
(See full trace by running task with --trace)
```
